### PR TITLE
Enable to post a message to new Slack Apps incoming webhook

### DIFF
--- a/_au_plugins/Slack.ps1
+++ b/_au_plugins/Slack.ps1
@@ -54,7 +54,7 @@ $body = @{
       )
     }
   )
-} | ConvertTo-Json -Compress
+} | ConvertTo-Json -Compress -Depth 10
 
 $arguments = @{
   Uri = $WebHookUrl


### PR DESCRIPTION
Resolve #54 

新しい書式だと `text` フィールドが必須になっているので、空文字にして送付するようにしただけ。
Slackに投稿するメッセージ自体は `attachments` フィールドを使っている。`attachments` はレガシーという位置づけで
代わりに `blocks` フィールド ([Layout blocks](https://api.slack.com/reference/block-kit/blocks))を使うのが
推奨の書式ということらしい。

ただしメッセージの左ボーダーの色付けは`blocks`だとできないし、Custom Integrationのincoming webhookで`blocks`が
使えないっぽいので、`attachments`を引き続き使い続けることにしました。
